### PR TITLE
Print GHC version instead of stack version

### DIFF
--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -853,7 +853,7 @@ spaceship_haskell() {
   # The command is stack, so do not change this to haskell.
   _exists stack || return
 
-  local haskell_version=$(stack --numeric-version)
+  local haskell_version=$(stack ghc -- --numeric-version --no-install-ghc)
 
   _prompt_section \
     "$SPACESHIP_HASKELL_COLOR" \


### PR DESCRIPTION
I think it may be more helpful to see the GHC version instead of the stack version. This commit uses the `stack ghc` command to determine the version of GHC used by the current project.